### PR TITLE
Clarify README for accurate bid range

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once the reveal phase ends, Cloak enters the third and last phase - the mint pha
 
 At this time, the mint price is determined by taking the mean of all the revealed bids. The final mint price is the max of either this calculated price or the `minPrice` set by the Cloak creator.
 
-To incentivize bid accuracy, only bids that are in the range of [`resultPrice - flex * stdDev`, `resultPrice + flex * stdDev`], where `flex` is a scalar value set by the Cloak creator.
+To incentivize bid accuracy, only bids that are in the range of [`resultPrice - flex * stdDev`, `resultPrice + flex * stdDev`] are permitted to mint; `flex` is a scalar value set by the Cloak creator.
 
 Anyone who isn't in this range can call `forgo()` to withdraw their deposit token.
 


### PR DESCRIPTION
Is this right? Confused by this sentence, def missing some sort of verb clause? Figured I'd just offer this change rather than asking about it.

To incentivize accurate bids, only bids in this range will be successful, which prevents whales (or Cloak deployer) from submitting very high bids to guarantee winning?

I'd also appreciate a quick blurb about how the flex affects this outcome (am bad at maths). i.e. a `flex` value of `n` would create a wider range than a value of `y`?

thanks for this tho, really excited to try some of the drop strategies you and others have been researching!